### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dangiffen/2d329bdd-f6bd-42fb-a2f3-dc7560734602/c120e300-7c94-4fe9-b240-a98b59caf7fe/_apis/work/boardbadge/a5232226-5817-4f2b-9f53-61485b084497)](https://dev.azure.com/dangiffen/2d329bdd-f6bd-42fb-a2f3-dc7560734602/_boards/board/t/c120e300-7c94-4fe9-b240-a98b59caf7fe/Microsoft.RequirementCategory)
 # DGRepo
 A Repository
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#498](https://dev.azure.com/dangiffen/2d329bdd-f6bd-42fb-a2f3-dc7560734602/_workitems/edit/498). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.